### PR TITLE
Adding IPVS_DEST_ATTR_ADDR_FAMILY and fixing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+tags

--- a/api.go
+++ b/api.go
@@ -61,8 +61,8 @@ type Service struct {
 // Destination defines an IPVS destination (real server) in its
 // entirety.
 type Destination struct {
-	Address   net.IP
-	Port      uint16
+	Address net.IP
+	Port    uint16
 
 	FwdMethod FwdMethod
 	Weight    uint32
@@ -111,10 +111,11 @@ func (self *Service) attrs(full bool) nlgo.AttrSlice {
 
 // Dump Dest as nl attrs, using the Af of the corresponding Service.
 // If full, includes Dest setting attrs, otherwise only identifying attrs.
-func (self *Destination) attrs(service *Service, full bool) nlgo.AttrSlice {
+func (self *Destination) attrs(full bool) nlgo.AttrSlice {
 	var attrs nlgo.AttrSlice
 
 	attrs = append(attrs,
+		nlattr(IPVS_DEST_ATTR_ADDR_FAMILY, nlgo.U16(self.AddressFamily)),
 		nlattr(IPVS_DEST_ATTR_ADDR, packAddr(self.AddressFamily, self.Address)),
 		nlattr(IPVS_DEST_ATTR_PORT, packPort(self.Port)),
 	)

--- a/ipvs.go
+++ b/ipvs.go
@@ -91,7 +91,7 @@ func (i *Handle) ListDestinations(s *Service) (dsts []*Destination, err error) {
 		Handle: func(attrs nlgo.AttrMap) error {
 			if destAttrs := attrs.Get(IPVS_CMD_ATTR_DEST); destAttrs == nil {
 				return fmt.Errorf("IPVS_CMD_GET_DEST without IPVS_CMD_ATTR_DEST")
-			} else if dst, err := unpackDest(*s, destAttrs.(nlgo.AttrMap)); err != nil {
+			} else if dst, err := unpackDest(destAttrs.(nlgo.AttrMap)); err != nil {
 				return err
 			} else {
 				dsts = append(dsts, &dst)
@@ -202,7 +202,7 @@ func (i *Handle) fillAttrs(s *Service, d *Destination, sfull, dfull bool) nlgo.A
 		attrs = append(attrs, nlattr(IPVS_CMD_ATTR_SERVICE, s.attrs(sfull)))
 	}
 	if d != nil {
-		attrs = append(attrs, nlattr(IPVS_CMD_ATTR_DEST, d.attrs(s, dfull)))
+		attrs = append(attrs, nlattr(IPVS_CMD_ATTR_DEST, d.attrs(dfull)))
 	}
 	return attrs
 }

--- a/ipvs_nl_policy.go
+++ b/ipvs_nl_policy.go
@@ -74,6 +74,7 @@ var ipvs_dest_policy = nlgo.MapPolicy{
 		IPVS_DEST_ATTR_INACT_CONNS:   "INACT_CONNS",
 		IPVS_DEST_ATTR_PERSIST_CONNS: "PERSIST_CONNS",
 		IPVS_DEST_ATTR_STATS:         "STATS",
+		IPVS_DEST_ATTR_ADDR_FAMILY:   "AF",
 	},
 	Rule: map[uint16]nlgo.Policy{
 		IPVS_DEST_ATTR_ADDR:          nlgo.BinaryPolicy, // struct in6_addr
@@ -86,6 +87,7 @@ var ipvs_dest_policy = nlgo.MapPolicy{
 		IPVS_DEST_ATTR_INACT_CONNS:   nlgo.U32Policy,
 		IPVS_DEST_ATTR_PERSIST_CONNS: nlgo.U32Policy,
 		IPVS_DEST_ATTR_STATS:         ipvs_stats_policy,
+		IPVS_DEST_ATTR_ADDR_FAMILY:   nlgo.U16Policy,
 	},
 }
 

--- a/ipvs_test.go
+++ b/ipvs_test.go
@@ -276,5 +276,4 @@ func TestDestination(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
-	// clearIpvs(t)
 }

--- a/ipvs_test.go
+++ b/ipvs_test.go
@@ -111,7 +111,14 @@ func checkService(t *testing.T, checkPresent bool, protocol, schedMethod, servic
 	}
 }
 
+func clearIpvsState(t *testing.T) {
+	_, err := exec.Command("ipvsadm", "--clear").CombinedOutput()
+	require.NoError(t, err)
+}
+
 func TestService(t *testing.T) {
+	defer clearIpvsState(t)
+
 	i, err := New()
 	require.NoError(t, err)
 
@@ -161,10 +168,11 @@ func TestService(t *testing.T) {
 			checkService(t, false, protocol, lastMethod, serviceAddress)
 		}
 	}
-
 }
 
 func TestDestination(t *testing.T) {
+	defer clearIpvsState(t)
+
 	i, err := New()
 	require.NoError(t, err)
 
@@ -268,4 +276,5 @@ func TestDestination(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
+	// clearIpvs(t)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,15 +1,14 @@
 package libipvs
 
 import (
-	"encoding/binary"
 	"bytes"
-	"syscall"
-	"net"
+	"encoding/binary"
 	"fmt"
+	"net"
+	"syscall"
 
 	"github.com/hkwi/nlgo"
 )
-
 
 // Helper to build an nlgo.Attr
 func nlattr(typ uint16, value nlgo.NlaValue) nlgo.Attr {
@@ -128,12 +127,14 @@ func unpackService(attrs nlgo.AttrMap) (Service, error) {
 	return service, nil
 }
 
-func unpackDest(service Service, attrs nlgo.AttrMap) (Destination, error) {
+func unpackDest(attrs nlgo.AttrMap) (Destination, error) {
 	var dest Destination
 	var addr []byte
 
 	for _, attr := range attrs.Slice() {
 		switch attr.Field() {
+		case IPVS_DEST_ATTR_ADDR_FAMILY:
+			dest.AddressFamily = (AddressFamily)(attr.Value.(nlgo.U16))
 		case IPVS_DEST_ATTR_ADDR:
 			addr = ([]byte)(attr.Value.(nlgo.Binary))
 		case IPVS_DEST_ATTR_PORT:
@@ -155,7 +156,7 @@ func unpackDest(service Service, attrs nlgo.AttrMap) (Destination, error) {
 		}
 	}
 
-	if addrIP, err := unpackAddr(addr, service.AddressFamily); err != nil {
+	if addrIP, err := unpackAddr(addr, dest.AddressFamily); err != nil {
 		return dest, fmt.Errorf("ipvs:Dest.unpack: addr: %s", err)
 	} else {
 		dest.Address = addrIP

--- a/utils_test.go
+++ b/utils_test.go
@@ -76,14 +76,14 @@ func testServiceEquals(t *testing.T, testService Service, service Service) {
 
 func TestServiceUnpack(t *testing.T) {
 	testService := Service{
-		AddressFamily:        syscall.AF_INET,     // 2
-		Protocol:  syscall.IPPROTO_TCP, // 6
-		Address:      net.ParseIP("10.107.107.0"),
-		Port:      1337,
-		SchedName: "wlc",
-		Flags:     Flags{0, 0},
-		Timeout:   0,
-		Netmask:   0x00000000,
+		AddressFamily: syscall.AF_INET,     // 2
+		Protocol:      syscall.IPPROTO_TCP, // 6
+		Address:       net.ParseIP("10.107.107.0"),
+		Port:          1337,
+		SchedName:     "wlc",
+		Flags:         Flags{0, 0},
+		Timeout:       0,
+		Netmask:       0x00000000,
 	}
 	testBytes := []byte{
 		0x06, 0x00, 0x01, 0x00, // IPVS_SVC_ATTR_AF
@@ -138,12 +138,10 @@ func testDestEquals(t *testing.T, testDest Destination, dest Destination) {
 }
 
 func TestDest(t *testing.T) {
-	testService := Service{
-		AddressFamily: syscall.AF_INET6,
-	}
 	testDest := Destination{
-		Address: net.ParseIP("2001:db8:6b:6b::0"),
-		Port: 1337,
+		AddressFamily: syscall.AF_INET6,
+		Address:       net.ParseIP("2001:db8:6b:6b::0"),
+		Port:          1337,
 
 		FwdMethod: IP_VS_CONN_F_TUNNEL,
 		Weight:    10,
@@ -151,6 +149,7 @@ func TestDest(t *testing.T) {
 		LThresh:   0,
 	}
 	testAttrs := nlgo.AttrSlice{
+		nlattr(IPVS_DEST_ATTR_ADDR_FAMILY, nlgo.U16(syscall.AF_INET6)),
 		nlattr(IPVS_DEST_ATTR_ADDR, nlgo.Binary([]byte{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x6b, 0x00, 0x6b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})),
 		nlattr(IPVS_DEST_ATTR_PORT, nlgo.U16(0x3905)),
 		nlattr(IPVS_DEST_ATTR_FWD_METHOD, nlgo.U32(IP_VS_CONN_F_TUNNEL)),
@@ -160,7 +159,7 @@ func TestDest(t *testing.T) {
 	}
 
 	// pack
-	packAttrs := testDest.attrs(&testService, true)
+	packAttrs := testDest.attrs(true)
 	packBytes := packAttrs.Bytes()
 
 	if !bytes.Equal(packBytes, testAttrs.Bytes()) {
@@ -170,7 +169,7 @@ func TestDest(t *testing.T) {
 	// unpack
 	if unpackedAttrs, err := ipvs_dest_policy.Parse(packBytes); err != nil {
 		t.Fatalf("error ipvs_dest_policy.Parse: %s", err)
-	} else if unpackedDest, err := unpackDest(testService, unpackedAttrs.(nlgo.AttrMap)); err != nil {
+	} else if unpackedDest, err := unpackDest(unpackedAttrs.(nlgo.AttrMap)); err != nil {
 		t.Fatalf("error unpackDest: %s", err)
 	} else {
 		testDestEquals(t, testDest, unpackedDest)


### PR DESCRIPTION
This PR adds IPVS_DEST_ATTR_ADDR_FAMILY to Destination struct. By doing that, we remove the need of passing a service struct to pack and unpack destinations.

It also fixes some tests.