### PR TITLE
Use server address family for dest without address family in old kernel

### DIFF
--- a/ipvs.go
+++ b/ipvs.go
@@ -91,7 +91,7 @@ func (i *Handle) ListDestinations(s *Service) (dsts []*Destination, err error) {
 		Handle: func(attrs nlgo.AttrMap) error {
 			if destAttrs := attrs.Get(IPVS_CMD_ATTR_DEST); destAttrs == nil {
 				return fmt.Errorf("IPVS_CMD_GET_DEST without IPVS_CMD_ATTR_DEST")
-			} else if dst, err := unpackDest(destAttrs.(nlgo.AttrMap)); err != nil {
+			} else if dst, err := unpackDest(destAttrs.(nlgo.AttrMap), s.AddressFamily); err != nil {
 				return err
 			} else {
 				dsts = append(dsts, &dst)

--- a/utils.go
+++ b/utils.go
@@ -130,7 +130,7 @@ func unpackService(attrs nlgo.AttrMap) (Service, error) {
 	return service, nil
 }
 
-func unpackDest(attrs nlgo.AttrMap) (Destination, error) {
+func unpackDest(attrs nlgo.AttrMap, serverAddressFamily AddressFamily) (Destination, error) {
 	var dest Destination
 	var addr []byte
 
@@ -159,6 +159,12 @@ func unpackDest(attrs nlgo.AttrMap) (Destination, error) {
 		case IPVS_DEST_ATTR_STATS:
 			dest.Stats = unpackStats(attr)
 		}
+	}
+	// Linux kernel prior v3.18-rc1 does not have the af (address family) field
+	// in ip_vs_dest_user_kern, so use the address family in ip_vs_service_user_kern.
+	// https://github.com/torvalds/linux/commit/6cff339bbd5f9eda7a5e8a521f91a88d046e6d0c
+	if dest.AddressFamily == 0 {
+		dest.AddressFamily = serverAddressFamily
 	}
 
 	if addrIP, err := unpackAddr(addr, dest.AddressFamily); err != nil {


### PR DESCRIPTION
Linux kernel prior v3.18-rc1 does not have the af (address family) field
in ip_vs_dest_user_kern, so use the address family in ip_vs_service_user_kern.
https://github.com/torvalds/linux/commit/6cff339bbd5f9eda7a5e8a521f91a88d046e6d0c

This problem occrurs in CentOS 7 whose kernel version is 3.10.0-514.el7.x86_64.