### PR TITLE
Set Destination AddressFamily in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ func main() {
 	fmt.Printf("%#v\n", svcs)
 
 	dst := libipvs.Destination{
-		Address: net.ParseIP("172.192.100.1"),
-		Port:    80,
+		Address:       net.ParseIP("172.192.100.1"),
+		AddressFamily: syscall.AF_INET,
+		Port:          80,
 	}
 
 	if err := h.NewDestination(&svc, &dst); err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -48,8 +48,9 @@ func main() {
 	fmt.Printf("%#v\n", svcs)
 
 	dst := libipvs.Destination{
-		Address: net.ParseIP("172.192.100.1"),
-		Port:    80,
+		Address:       net.ParseIP("172.192.100.1"),
+		AddressFamily: syscall.AF_INET,
+		Port:          80,
 	}
 
 	if err := h.NewDestination(&svc, &dst); err != nil {


### PR DESCRIPTION
Without this fix, the example panics:
panic: ipvs:packAddr: unknown af=0 addr=172.192.100.1